### PR TITLE
fix(provider): enhance error handling and type parsing in evaluations

### DIFF
--- a/pkg/toggle/provider.go
+++ b/pkg/toggle/provider.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/open-feature/go-sdk/openfeature"
@@ -102,14 +103,57 @@ func (p *Provider) BooleanEvaluation(ctx context.Context, flag string, defaultVa
 		}
 	}
 
-	if toggle, ok := eval.Toggles[flag]; ok && toggle.Type == "boolean" {
-		if value, ok := toggle.Value.(bool); ok {
-			return openfeature.BoolResolutionDetail{
-				Value: value,
-				ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
-					Reason: openfeature.TargetingMatchReason,
-				},
+	if toggle, ok := eval.Toggles[flag]; ok {
+		if strings.EqualFold(toggle.Type, "boolean") {
+
+			switch v := toggle.Value.(type) {
+			case bool:
+				return openfeature.BoolResolutionDetail{
+					Value: v,
+					ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+						Reason: openfeature.TargetingMatchReason,
+					},
+				}
+			case string:
+				if strings.EqualFold(v, "true") {
+					return openfeature.BoolResolutionDetail{
+						Value: true,
+						ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+							Reason: openfeature.TargetingMatchReason,
+						},
+					}
+				} else if strings.EqualFold(v, "false") {
+					return openfeature.BoolResolutionDetail{
+						Value: false,
+						ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+							Reason: openfeature.TargetingMatchReason,
+						},
+					}
+				}
+				return openfeature.BoolResolutionDetail{
+					Value: defaultValue,
+					ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+						Reason:          openfeature.ErrorReason,
+						ResolutionError: openfeature.NewTypeMismatchResolutionError(fmt.Sprintf("invalid boolean string value: %s", v)),
+					},
+				}
+			default:
+				fmt.Printf("Unmatched type: %T\n", v)
+				return openfeature.BoolResolutionDetail{
+					Value: defaultValue,
+					ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+						Reason:          openfeature.ErrorReason,
+						ResolutionError: openfeature.NewTypeMismatchResolutionError(fmt.Sprintf("value type assertion failed, got type: %T", toggle.Value)),
+					},
+				}
 			}
+		}
+		return openfeature.BoolResolutionDetail{
+			Value: defaultValue,
+			ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+				Reason:          openfeature.ErrorReason,
+				ResolutionError: openfeature.NewTypeMismatchResolutionError(fmt.Sprintf("expected type 'boolean', got '%s'", toggle.Type)),
+			},
 		}
 	}
 
@@ -117,7 +161,7 @@ func (p *Provider) BooleanEvaluation(ctx context.Context, flag string, defaultVa
 		Value: defaultValue,
 		ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
 			Reason:          openfeature.ErrorReason,
-			ResolutionError: openfeature.NewTypeMismatchResolutionError("invalid flag type"),
+			ResolutionError: openfeature.NewTypeMismatchResolutionError(fmt.Sprintf("flag '%s' not found in toggles", flag)),
 		},
 	}
 }
@@ -169,6 +213,7 @@ func (p *Provider) StringEvaluation(
 		},
 	}
 }
+
 func (p *Provider) FloatEvaluation(ctx context.Context, flag string, defaultValue float64, evalCtx openfeature.FlattenedContext) openfeature.FloatResolutionDetail {
 	hyphenCtx, err := p.buildContext(evalCtx)
 	if err != nil {
@@ -215,13 +260,22 @@ func (p *Provider) FloatEvaluation(ctx context.Context, flag string, defaultValu
 					Reason: openfeature.TargetingMatchReason,
 				},
 			}
+		case string:
+			if f, err := strconv.ParseFloat(v, 64); err == nil {
+				return openfeature.FloatResolutionDetail{
+					Value: f,
+					ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+						Reason: openfeature.TargetingMatchReason,
+					},
+				}
+			}
 		}
 	}
 
 	return openfeature.FloatResolutionDetail{
 		Value: defaultValue,
 		ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
-			ResolutionError: openfeature.NewTypeMismatchResolutionError(ErrInvalidFlagType.Error()),
+			ResolutionError: openfeature.NewTypeMismatchResolutionError("invalid flag type"),
 			Reason:          openfeature.ErrorReason,
 		},
 	}
@@ -273,13 +327,22 @@ func (p *Provider) IntEvaluation(ctx context.Context, flag string, defaultValue 
 					Reason: openfeature.TargetingMatchReason,
 				},
 			}
+		case string:
+			if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+				return openfeature.IntResolutionDetail{
+					Value: i,
+					ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
+						Reason: openfeature.TargetingMatchReason,
+					},
+				}
+			}
 		}
 	}
 
 	return openfeature.IntResolutionDetail{
 		Value: defaultValue,
 		ProviderResolutionDetail: openfeature.ProviderResolutionDetail{
-			ResolutionError: openfeature.NewTypeMismatchResolutionError(ErrInvalidFlagType.Error()),
+			ResolutionError: openfeature.NewTypeMismatchResolutionError("invalid flag type"),
 			Reason:          openfeature.ErrorReason,
 		},
 	}
@@ -325,26 +388,72 @@ func (p *Provider) ObjectEvaluation(ctx context.Context, flag string, defaultVal
 		},
 	}
 }
+
 func (p *Provider) buildContext(evalCtx openfeature.FlattenedContext) (EvaluationContext, error) {
 	targetingKey, ok := evalCtx["targetingKey"].(string)
 	if !ok {
 		return EvaluationContext{}, ErrMissingTargetKey
 	}
 
+	// Extract user data from the context
+	userData, ok := evalCtx["user"].(map[string]interface{})
+	if !ok {
+		userData = make(map[string]interface{})
+	}
+
+	// Create User struct with data from the nested structure
+	user := &User{
+		ID:    getString(userData, "id", targetingKey),
+		Email: getString(userData, "email", ""),
+		Name:  getString(userData, "name", ""),
+	}
+
+	// Handle user custom attributes
+	if customAttrs, ok := userData["customAttributes"].(map[string]interface{}); ok {
+		user.CustomAttributes = customAttrs
+	} else {
+		user.CustomAttributes = make(map[string]interface{})
+	}
+
+	// Build the evaluation context
 	ctx := EvaluationContext{
 		TargetingKey:     targetingKey,
 		Application:      p.config.Application,
 		Environment:      p.config.Environment,
+		User:             user,
 		CustomAttributes: make(map[string]interface{}),
 	}
 
+	// Add remaining top-level attributes to customAttributes
 	for k, v := range evalCtx {
-		if k != "targetingKey" {
+		switch k {
+		case "targetingKey", "user":
+			continue
+		default:
 			ctx.CustomAttributes[k] = v
 		}
 	}
 
 	return ctx, nil
+}
+
+// Helper function to safely get string values from map
+func getString(m map[string]interface{}, key string, defaultValue string) string {
+	if val, ok := m[key].(string); ok {
+		return val
+	}
+	return defaultValue
+}
+
+// Helper function to determine if an attribute belongs to user
+func isUserAttribute(key string) bool {
+	userAttributes := map[string]bool{
+		"role":    true,
+		"group":   true,
+		"company": true,
+		// Add other user-specific attributes as needed
+	}
+	return userAttributes[key]
 }
 
 func (p *Provider) Hooks() []openfeature.Hook {


### PR DESCRIPTION
1. Added handling for toggles where boolean values may be given as a string.
2. Added string parsing for float and integer evaluations, if the value given is a string.
3. Switched out static error messages for more dynamic and informative ones based on the flag type.
4. Enhanced user data extraction from the evaluation context and added user custom attributes.
5. Added helper functions to safely extract string values from maps and to determine if an attribute belongs to a user.